### PR TITLE
Update link to CI badge, bump to latest ghc patch versions

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16.3
+# version: 0.16.6
 #
-# REGENDATA ("0.16.3",["github","diagrams.cabal"])
+# REGENDATA ("0.16.6",["github","diagrams.cabal"])
 #
 name: Haskell-CI
 on:
@@ -28,9 +28,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.1
+          - compiler: ghc-9.6.2
             compilerKind: ghc
-            compilerVersion: 9.6.1
+            compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.5
@@ -38,9 +38,9 @@ jobs:
             compilerVersion: 9.4.5
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.2.7
+          - compiler: ghc-9.2.8
             compilerKind: ghc
-            compilerVersion: 9.2.7
+            compilerVersion: 9.2.8
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.0.2

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-[![Build Status](https://github.com/diagrams/diagrams/actions/workflows/haskell-ci.yml/badge.svg)](https://github.com/diagrams/diagrams/actions/workflows/haskell-ci.yml/badge.svg)
+[![Build Status](https://github.com/diagrams/diagrams/actions/workflows/haskell-ci.yml/badge.svg)](https://github.com/diagrams/diagrams/actions/workflows/haskell-ci.yml)
 
 [diagrams] is a full-featured framework and domain-specific language
 (embedded in [Haskell]) for creating declarative vector graphics and

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-[![Build Status](http://gondor.hendrix.edu:8080/buildStatus/icon?job=Diagrams HEAD)](http://gondor.hendrix.edu:8080/job/Diagrams%20HEAD/)
+[![Build Status](https://github.com/diagrams/diagrams/actions/workflows/haskell-ci.yml/badge.svg)](https://github.com/diagrams/diagrams/actions/workflows/haskell-ci.yml/badge.svg)
 
 [diagrams] is a full-featured framework and domain-specific language
 (embedded in [Haskell]) for creating declarative vector graphics and

--- a/diagrams.cabal
+++ b/diagrams.cabal
@@ -73,7 +73,7 @@ Bug-reports:         http://github.com/diagrams/diagrams/issues
 Category:            Graphics
 Build-type:          Simple
 Cabal-version:       1.18
-tested-with:         GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.7 || ==9.4.5 || ==9.6.1
+tested-with:         GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.5 || ==9.6.2
 Extra-source-files:  README.markdown
 extra-doc-files:     CHANGES.md
 


### PR DESCRIPTION
Thanks for updating the package to most recent GHC versions, just as I got back to using it :smile: 

Here's just update to CI badge shown in readme + bump to latest patch versions of GHC.

I'd also suggest that you could add link to [diagrams website](https://diagrams.github.io/) to the About section of this repo, like this:

![Peek 2023-07-27 14-05](https://github.com/diagrams/diagrams/assets/2716069/3fe860cb-9fad-4d05-8400-b6fa85b58ba3)


Companion PRs:
https://github.com/diagrams/diagrams-lib/pull/361
https://github.com/diagrams/diagrams-core/pull/121
https://github.com/diagrams/diagrams-svg/pull/120